### PR TITLE
ci: auto-deploy preview updates from main

### DIFF
--- a/.github/workflows/preview-update-on-main.yml
+++ b/.github/workflows/preview-update-on-main.yml
@@ -1,0 +1,48 @@
+name: Preview Update On Main
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: preview-update-main
+  cancel-in-progress: true
+
+jobs:
+  publish-preview-update:
+    name: Publish EAS preview update
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate EXPO_TOKEN secret
+        run: |
+          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
+            echo "Missing EXPO_TOKEN secret. Add it in repository secrets."
+            exit 1
+          fi
+
+      - name: Setup EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          token: ${{ secrets.EXPO_TOKEN }}
+          eas-version: latest
+
+      - name: Publish update to preview channel
+        run: npx eas update --channel preview --auto --non-interactive

--- a/README.md
+++ b/README.md
@@ -250,6 +250,11 @@ Build preview:
 eas build --profile preview
 ```
 
+Auto-publish preview updates on `main`:
+
+- See `docs/release/preview-auto-deploy.md`
+- Requires GitHub secret `EXPO_TOKEN`
+
 Internal dev client build:
 
 ```bash

--- a/docs/release/preview-auto-deploy.md
+++ b/docs/release/preview-auto-deploy.md
@@ -1,0 +1,27 @@
+# Preview Auto Deploy From `main`
+
+This project is configured to publish an EAS preview update on every push to `main`.
+
+## What is automated
+
+- Workflow: `.github/workflows/preview-update-on-main.yml`
+- Trigger: `push` to `main` (and manual `workflow_dispatch`)
+- Action: `eas update --channel preview --auto --non-interactive`
+- Build profile channel: `preview` in `eas.json`
+
+## One-time setup
+
+1. Create an Expo access token (Expo account settings).
+2. Add GitHub repository secret:
+   - Name: `EXPO_TOKEN`
+   - Value: your Expo access token
+
+## Important behavior
+
+- This workflow publishes OTA updates (JavaScript/assets) to the `preview` channel.
+- A device only receives these updates if the installed binary is built for channel `preview`.
+- Native code/config changes still require a new EAS Build and reinstall.
+
+## First install / channel migration
+
+If you previously installed a preview build without channel `preview`, install one fresh preview build after this change so your phone is pinned to the correct channel.

--- a/eas.json
+++ b/eas.json
@@ -14,6 +14,7 @@
     },
     "preview": {
       "distribution": "internal",
+      "channel": "preview",
       "android": {
         "buildType": "apk"
       },


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish an EAS preview update on every push to main
- set preview build profile channel to preview in eas.json
- document required setup and behavior in docs/release/preview-auto-deploy.md
- add README pointer for the new automation

## Workflow
- file: .github/workflows/preview-update-on-main.yml
- trigger: push to main + manual dispatch
- command: eas update --channel preview --auto --non-interactive

## Required setup
- add repository secret EXPO_TOKEN
- install a fresh preview build once after this PR (to ensure devices are pinned to channel preview)

## Notes
- this automates OTA JS/assets updates
- native changes still require a new preview build
